### PR TITLE
refactor Game state initialization

### DIFF
--- a/src/components/game.js
+++ b/src/components/game.js
@@ -5,26 +5,28 @@ import GuessForm from './guess-form'
 import Results from './results'
 import PlayAgain from './play-again'
 
+const DEFAULT_MAX = 100;
+const DEFAULT_MIN = 0;
+
 export default class Game extends React.Component {
 
   constructor(props) {
     super(props);
+
+    // initialize state
     this.state = {
-      targetNumber: randomNumber(0, 100),
-      max: 100,
-      min: 0,
-      currentGuess: {
-        number: "",
-        result: ""
-      },
-      allGuesses: [],
-      correct: false
+      max: DEFAULT_MAX,
+      min: DEFAULT_MIN
     }
 
     //Setup proper "this" bindings so functions below have access to "this"
     this.updateCurrentGuess = this.updateCurrentGuess.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
     this.resetGame = this.resetGame.bind(this);
+  }
+
+  componentWillMount() {
+    this.resetGame();
   }
 
   updateCurrentGuess(number) {


### PR DESCRIPTION
Here are a few ways you can update your state initialization so that the "targetNumber" is generated from the state's min and max: 

1. Hook into the lifecycle method [`componentWillMount`](https://reactjs.org/docs/react-component.html#componentwillmount) and call `resetGame()` which is already available
2. Set the default values for `min` and `max` to some other variable and have `min`, `max`, and `targetNumber` all reference those variables.

In this commit, I went with the first approach, but also captured the default min and max into a constant variable. 

